### PR TITLE
Add richer event data and timeline UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,3 +8,33 @@ body {
   display: flex;
   height: 100vh;
 }
+.chat-panel {
+  flex: 2;
+  padding: 1rem;
+}
+.timeline-rail {
+  flex: 1;
+  padding: 1rem;
+  border-left: 1px solid #444;
+}
+.timeline-rail ul {
+  list-style: none;
+  padding: 0;
+}
+.timeline-rail li {
+  padding: 0.25rem 0;
+}
+.timeline-rail li.active {
+  color: #0f0;
+}
+.timeline-rail .shape {
+  margin-left: 0.25rem;
+}
+.citation-panel {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 0.5rem;
+  max-width: 300px;
+}

--- a/components/ChatPanel.tsx
+++ b/components/ChatPanel.tsx
@@ -1,9 +1,35 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useTimelineStore } from '../lib/store';
+import eventsData from '../data/events.json';
+
+function getYear(dateIso: string) {
+  return new Date(dateIso).getUTCFullYear();
+}
 
 export default function ChatPanel() {
+  const { events, currentIndex, next, prev, setEvents } = useTimelineStore();
+
+  useEffect(() => {
+    if (events.length === 0) {
+      setEvents(eventsData as any);
+    }
+  }, [events.length, setEvents]);
+
+  const event = events[currentIndex];
   return (
-    <section className="chat-panel" aria-label="Chat panel placeholder">
-      <p>ChatPanel</p>
+    <section className="chat-panel" aria-label="Chat panel">
+      {event ? (
+        <>
+          <h2>{getYear(event.dateIso)} – {event.title}</h2>
+          <p>{event.summary}</p>
+          <div className="chat-controls">
+            <button onClick={prev} aria-label="Previous event">Prev</button>
+            <button onClick={next} aria-label="Next event">Next</button>
+          </div>
+        </>
+      ) : (
+        <p>Loading...</p>
+      )}
     </section>
   );
 }

--- a/components/CitationPanel.tsx
+++ b/components/CitationPanel.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
+import { useTimelineStore } from '../lib/store';
 
 export default function CitationPanel() {
+  const { events, currentIndex } = useTimelineStore();
+  const event = events[currentIndex];
+
   return (
-    <div className="citation-panel" aria-label="Citation panel placeholder">
-      <p>CitationPanel</p>
+    <div className="citation-panel" aria-label="Citations">
+      {event ? (
+        <ul>
+          {event.citations.map((c) => (
+            <li key={c.url}>
+              <a href={c.url} target="_blank" rel="noopener noreferrer">
+                {c.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No citations</p>
+      )}
     </div>
   );
 }

--- a/components/TimelineRail.tsx
+++ b/components/TimelineRail.tsx
@@ -1,9 +1,29 @@
 import React from 'react';
+import { useTimelineStore } from '../lib/store';
+
+function yearFromIso(dateIso: string) {
+  return new Date(dateIso).getUTCFullYear();
+}
 
 export default function TimelineRail() {
+  const { events, currentIndex, setEvents } = useTimelineStore();
+
+  React.useEffect(() => {
+    if (events.length === 0) {
+      import('../data/events.json').then(mod => setEvents(mod.default as any));
+    }
+  }, [events.length, setEvents]);
+
   return (
-    <aside className="timeline-rail" aria-label="Timeline placeholder">
-      <p>TimelineRail</p>
+    <aside className="timeline-rail" aria-label="Timeline">
+      <ul>
+        {events.map((ev, idx) => (
+          <li key={ev.id} className={idx === currentIndex ? 'active' : ''}>
+            <span className="year">{yearFromIso(ev.dateIso)}</span>{' '}
+            <span className="shape">{ev.gemShape === 'star' ? '★' : ev.gemShape === 'pentagon' ? '⬟' : '⬣'}</span>
+          </li>
+        ))}
+      </ul>
     </aside>
   );
 }

--- a/data/events.json
+++ b/data/events.json
@@ -1,1 +1,50 @@
-[]
+[
+  {
+    "id": "ajax-1953-coup",
+    "dateIso": "1953-08-19",
+    "title": "CIA/MI6 Operation Ajax",
+    "summary": "US and UK orchestrate coup overthrowing Iran's PM Mossadegh.",
+    "importance": 1,
+    "gemShape": "pentagon",
+    "sceneRef": "ajax-1953-coup",
+    "citations": [
+      {"url": "https://en.wikipedia.org/wiki/1953_Iranian_coup_d%27%C3%A9tat", "label": "Wikipedia"}
+    ]
+  },
+  {
+    "id": "jcpoa-sign",
+    "dateIso": "2015-07-14",
+    "title": "JCPOA Nuclear Deal Signed",
+    "summary": "Iran and world powers sign nuclear accord after years of negotiation.",
+    "importance": 1,
+    "gemShape": "star",
+    "sceneRef": "jcpoa-sign",
+    "citations": [
+      {"url": "https://en.wikipedia.org/wiki/Joint_Comprehensive_Plan_of_Action", "label": "Wikipedia"}
+    ]
+  },
+  {
+    "id": "soleimani-drone",
+    "dateIso": "2020-01-03",
+    "title": "Soleimani Drone Strike",
+    "summary": "US drone strike kills Iranian General Qasem Soleimani near Baghdad.",
+    "importance": 1,
+    "gemShape": "star",
+    "sceneRef": "soleimani-drone",
+    "citations": [
+      {"url": "https://en.wikipedia.org/wiki/Qasem_Soleimani", "label": "Wikipedia"}
+    ]
+  },
+  {
+    "id": "mahsa-amini",
+    "dateIso": "2022-09-16",
+    "title": "Mahsa Amini Protests",
+    "summary": "Death of Mahsa Amini sparks nationwide protests in Iran.",
+    "importance": 1,
+    "gemShape": "star",
+    "sceneRef": "mahsa-amini",
+    "citations": [
+      {"url": "https://en.wikipedia.org/wiki/Mahsa_Amini", "label": "Wikipedia"}
+    ]
+  }
+]

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+export interface EventNode {
+  id: string;
+  dateIso: string;
+  title: string;
+  summary: string;
+  importance: 0 | 1;
+  gemShape: 'star' | 'pentagon' | 'heptagon';
+  sceneRef: string;
+  citations: { url: string; label: string }[];
+  tags?: string[];
+  geo?: { lat: number; lon: number };
+}
+
+interface TimelineState {
+  events: EventNode[];
+  currentIndex: number;
+  next: () => void;
+  prev: () => void;
+  setEvents: (events: EventNode[]) => void;
+}
+
+export const useTimelineStore = create<TimelineState>((set, get) => ({
+  events: [],
+  currentIndex: 0,
+  next: () => set(state => ({ currentIndex: Math.min(state.currentIndex + 1, state.events.length - 1) })),
+  prev: () => set(state => ({ currentIndex: Math.max(state.currentIndex - 1, 0) })),
+  setEvents: (events) => set({ events, currentIndex: 0 }),
+}));


### PR DESCRIPTION
## Summary
- model full EventNode schema in Zustand store
- expand sample events data with title, summary and citation labels
- show event titles in ChatPanel
- display year and gem shape in TimelineRail
- tweak global styles for timeline

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6dad76fc83279fa88115b10a71e4